### PR TITLE
Marking this repo / project name outdated and linking to ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # fw1-template
 
-A [Leiningen](https://github.com/technomancy/leiningen) template for [FW/1](https://github.com/seancorfield/fw1-clj) (Framework One).
+OUTDATED: USE [fw1/lein-template](https://github.com/framework-one/fw1-template) INSTEAD!
+
+A [Leiningen](https://github.com/technomancy/leiningen) template for [FW/1](https://github.com/framework-one/fw1-clj) (Framework One).
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,2 +1,2 @@
-(defproject fw1-template "0.1.0"
-  :description "FW/1 template for lein newnew")
+(defproject fw1-template "0.1.1"
+  :description "Outdated FW/1 template - use fw1/lein-template instead - see https://github.com/framework-one/fw1-template")


### PR DESCRIPTION
https://github.com/framework-one/fw1-template instead.
